### PR TITLE
Fix issue prevent proper UAFilterableResultsChange call for moving items.

### DIFF
--- a/Code/UAFilterableResultsController/UAFilterableResultsController.m
+++ b/Code/UAFilterableResultsController/UAFilterableResultsController.m
@@ -1246,7 +1246,7 @@
             id obj = [section objectAtIndex:rowIndex];
             
             // alrighty, does this object exist in the old one?
-            NSIndexPath *pathInExisting = [self indexPathOfObject:obj inArray:fromMutable usingKeyPath:nil];
+            NSIndexPath *pathInExisting = [self indexPathOfObject:obj inArray:fromArray usingKeyPath:nil];
             if (pathInExisting == nil)
             {
                 // nope, lets notify about it


### PR DESCRIPTION
Fixes an issue that caused items to be be sent signals for deletion then then insertion instead of move.
